### PR TITLE
日付が重複しないようにした

### DIFF
--- a/lib/ruboty/actions/google_spreadsheet/base.rb
+++ b/lib/ruboty/actions/google_spreadsheet/base.rb
@@ -58,7 +58,7 @@ module Ruboty
         end
 
         def dates
-          @dates = [message[:start_date], message[:end_date]].compact
+          @dates = [message[:start_date], message[:end_date]].compact.uniq
         end
 
         def date(date)


### PR DESCRIPTION
## :sparkles: 目的

コマンドで受け取る日付は2つあるが、2つが重複した日付でも2行のスプレッドシートが書き込まれてしまう。
これを解決する。

## :muscle: 方針

`Array#uniq`メソッドを使う。

## :white_check_mark: テスト

実際に動作させて重複しないことを確認した。