### PR TITLE
2日以上続く予定を指定した場合に間の予定が登録されない問題を修正した

### DIFF
--- a/lib/ruboty/actions/google_spreadsheet/base.rb
+++ b/lib/ruboty/actions/google_spreadsheet/base.rb
@@ -46,7 +46,7 @@ module Ruboty
 
         def row_data(index)
           data[num_rows + 1, 1] = 'reserved'
-          row_data = [message.from_name, date(dates[index]), holiday_type, note]
+          row_data = [message.from_name, dates[index], holiday_type, note]
 
           row_data.each_with_index do |elm, idx|
             data[num_rows, idx + 1] = elm
@@ -58,11 +58,9 @@ module Ruboty
         end
 
         def dates
-          @dates = [message[:start_date], message[:end_date]].compact.uniq
-        end
-
-        def date(date)
-          Date.parse(date).strftime('%Y/%m/%d')
+          @dates = (Date.parse(message[:start_date])..Date.parse(message[:end_date])).map do |date|
+            date.strftime('%Y/%m/%d')
+          end
         end
 
         def holiday_type


### PR DESCRIPTION
## :sparkles: 目的

2日以上続く予定を登録しようとした場合に、間の予定が登録されていなかった。
これを解決する。

## 📷 スクリーンショット

### 修正前
<img width="435" alt="screen shot 2018-05-23 at 11 33 10" src="https://user-images.githubusercontent.com/23367170/40400456-2b1de962-5e7d-11e8-8161-02660131477d.png">

### 修正後
<img width="434" alt="screen shot 2018-05-23 at 11 30 43" src="https://user-images.githubusercontent.com/23367170/40400459-2f828a08-5e7d-11e8-8660-921f6d591c3e.png">

## :muscle: 方針

開始日と終了日のみ受け取って配列を作っていたが、開始日から終了日の間の日付を生成して配列を作るようにした。

## :white_check_mark: テスト

Rubocopが通ることを確認した。
実際に動かして、間の日付が登録されることを確認した。