### PR TITLE
カレンダーのタイトルに備考を追加した

### DIFF
--- a/lib/ruboty/actions/google_calendar/base.rb
+++ b/lib/ruboty/actions/google_calendar/base.rb
@@ -18,7 +18,7 @@ module Ruboty
         def create_event
           client.create_event(
             calendar_id: ENV['GOOGLE_CALENDAR_ID'],
-            summary: "#{message.from_name}#{holiday_type}",
+            summary: "#{message.from_name}#{holiday_type}: #{message[:note]}",
             start_date: message[:start_date],
             end_date: message[:end_date]
           )


### PR DESCRIPTION
## :sparkles: 目的

カレンダーのタイトルに備考を追加する。

## :muscle: 方針

`<ユーザ名><休暇種別>: <備考>`のフォーマットで表示する。

## :white_check_mark: テスト

実際に動かして動作することを確認した。